### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/proxy_test.yaml
+++ b/.github/workflows/proxy_test.yaml
@@ -1,5 +1,8 @@
 name: Python Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/childmindresearch/doc-bot/security/code-scanning/1](https://github.com/childmindresearch/doc-bot/security/code-scanning/1)

To fix the issue, you should set an explicit `permissions` key at the top level of the workflow YAML file, directly under the `name:` or `on:` block, to limit the GITHUB_TOKEN's permissions for all jobs in the workflow. The recommended minimal permissions are `contents: read`, unless you know a job needs broader permissions. This change ensures that jobs do not run with more privileges than necessary. No imports or other code outside the shown workflow snippet are required, and no further lines in this workflow need to be modified except for the insertion of the `permissions:` block near the top.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
