### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/proxy_test.yaml
+++ b/.github/workflows/proxy_test.yaml
@@ -1,4 +1,6 @@
 name: Python Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/childmindresearch/doc-bot/security/code-scanning/29](https://github.com/childmindresearch/doc-bot/security/code-scanning/29)

To fix the problem, you should add a `permissions` key with the least privilege possible. Since all jobs in this workflow only require read access (or possibly no GitHub token access at all, but the strictest reasonable is `contents: read`) you should specify the `permissions` key at the top level of the workflow file. This will apply the minimal necessary permission to all jobs unless overridden. The changes should be applied near the root of `.github/workflows/proxy_test.yaml`, after the workflow `name` field and before (or after) the `on` block.

**Steps:**
- Insert a single permissions block at the root (after `name`, before or after `on`).
- Use:  
  ```yaml
  permissions:
    contents: read
  ```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
