### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,6 @@
 name: Publish Docker image
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/childmindresearch/doc-bot/security/code-scanning/3](https://github.com/childmindresearch/doc-bot/security/code-scanning/3)

To fix this problem, add a `permissions:` block that explicitly declares minimal required permissions for the workflow. The best approach is to specify `permissions: contents: read` at the workflow root level, which applies to all jobs unless otherwise specified. This ensures the GITHUB_TOKEN in all jobs has read access to the repository contents and nothing more. You only need to modify the beginning portion of `.github/workflows/release.yaml`, inserting a `permissions:` block right after the workflow `name` and before the `on:` trigger. No other changes are needed unless specific jobs require additional permissions (which does not appear to be the case based on the shown code).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
